### PR TITLE
Remove strong naming

### DIFF
--- a/src/Options.WinRT/Options.WinRT.csproj
+++ b/src/Options.WinRT/Options.WinRT.csproj
@@ -100,9 +100,6 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <KeyContainerName>Options</KeyContainerName>
-  </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
   </ItemGroup>

--- a/src/Options/Options.csproj
+++ b/src/Options/Options.csproj
@@ -41,9 +41,6 @@
     <DocumentationFile>bin\Release\Options.XML</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- KeyContainerName>Options</KeyContainerName -->
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Options/Options.csproj
+++ b/src/Options/Options.csproj
@@ -42,7 +42,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <KeyContainerName>Options</KeyContainerName>
+    <!-- KeyContainerName>Options</KeyContainerName -->
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">


### PR DESCRIPTION
After years of believing in strong naming, almost mystically, I am giving up on using it as any kind of security mechanism. If people say that they would like strong naming back, I am happy to accept pull requests that implement it.
